### PR TITLE
Deploy and fix display of movie details

### DIFF
--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -194,11 +194,23 @@ class App extends Component {
     return possibleSuggestions
   }
 
+  showGenres = (activity) => {
+    let allGenres = [];
+    if (activity.genre) {
+      activity.genre.forEach((genre, i) => {
+        if (i <= 2) {
+          allGenres.push(genre);
+        }
+      })
+      return allGenres.map(genre => <h3 className='title'>{genre}</h3>)
+    }
+  }
+
   render() {
     return (
       <div className="App">
         <Switch>
-          <Route exact path='/'>
+          <Route exact path='/indecision-maker'>
             <Homepage
               getActivityData={this.getActivityData}
               allMovies={this.state.movies}
@@ -242,6 +254,7 @@ class App extends Component {
                 randomActivity={this.state.randomActivity}
                 determineRandomActivity={this.determineRandomActivity}
                 error={this.state.error}
+                showGenres={this.showGenres}
               />
             }}>
           </Route>

--- a/src/Components/Form/Form.js
+++ b/src/Components/Form/Form.js
@@ -216,7 +216,7 @@ export class Form extends Component {
         <div className="bar-menu">
           <CgUserlane className="logo" />
           <Link 
-            to="/" 
+            to="/indecision-maker" 
             onClick={() => this.props.resetState()}>
             <RiHomeSmileLine className="logo" />
           </Link>

--- a/src/Components/ResultPage/ResultPage.js
+++ b/src/Components/ResultPage/ResultPage.js
@@ -33,7 +33,8 @@ export const ResultPage = (props) => {
           </h3>
           {activity.release_date && 
           <h3 className="title">{moment(activity.release_date).format('LL')}</h3>}
-          <h3 className="title">{activity.genre|| activity.type}</h3>
+          {props.showGenres(activity)}
+          <h3 className="title">{activity.type}</h3>
           {activity.average_time &&
            <h3 className="title">{`Play Time: ${activity.average_time} mins`}</h3>}
           {activity.min_players  &&


### PR DESCRIPTION
#### What's this PR do?  

+ Should successfully deploy the frontend at `nicolegooden.github.io/indecision-maker/
+ Updates paths based on deployment, from `/` to `/indecision-maker`
+ Displays movie genres on `ResultPage` on separate lines, rather than in one line without spacing

#### Where should the reviewer start? 

Start in `ResultPage` and then in `App` to view the `showGenres()` method.  

#### How should this be manually tested?  

Pull down the changes locally and fill out the form based on interest in movies.  Ensure the result page shows genres in a human-readable way (the similar picks section).  Also, go to the deployed link to see if it works on your end.

#### Any background context you want to provide?  

The deployed app was working before this PR had been opened.  Waiting on the home logo/button to route the user back to the homepage; I've added this path in this PR.

#### What are the relevant tickets?  

Closes #80 
Closes #81 

#### Screenshots (if appropriate) 

![Screen Shot 2020-11-20 at 4 38 09 PM](https://user-images.githubusercontent.com/62262404/99859916-cbb4cf80-2b4e-11eb-8bd6-b5fe3d6d738f.png)

